### PR TITLE
Changes from spm-loaders

### DIFF
--- a/include/wii/nand.h
+++ b/include/wii/nand.h
@@ -22,6 +22,8 @@ CPP_WRAPPER(wii::nand)
 #define NAND_MODE_READ 1
 #define NAND_MODE_WRITE 2
 
+#define NAND_PATH_LENGTH 64
+
 typedef struct
 {
 /* 0x00 */ u8 unknown_0x0[0x8c - 0x0];

--- a/linker/spm.eu0.lst
+++ b/linker/spm.eu0.lst
@@ -637,10 +637,15 @@
 // more
 
 // mem.a
+// mem_heapCommon.c
+8029540c:MEMFindContainHeap
+// more
 // mem_expHeap.c
 80295b3c:MEMAllocFromExpHeapEx
+80295bec:MEMFreeToExpHeap
 80295cb8:MEMGetAllocatableSizeForExpHeapEx
 80295d90:MEMGetSizeForMBlockExpHeap
+// more
 
 // ipc.a
 80298268:IOS_Open

--- a/linker/spm.eu0.lst
+++ b/linker/spm.eu0.lst
@@ -482,7 +482,7 @@
 // relmgr.c
 // text
 8023e434:relInit
-8023e444:loadRel
+8023e444:relMain
 8023e600:isRelLoaded
 // sdata
 805ae1a0:relmgr_wp

--- a/linker/spm.jp0.lst
+++ b/linker/spm.jp0.lst
@@ -135,7 +135,7 @@
 8023509C:wpadGetButtonsHeldRepeat
 8023A2E8:spsndBGMOn
 8023BDE8:relInit
-8023BDF8:loadRel
+8023BDF8:relMain
 8023BFB4:isRelLoaded
 805424C0:relmgr_wp
 805424C4:relDecompName

--- a/linker/spm.jp1.lst
+++ b/linker/spm.jp1.lst
@@ -135,7 +135,7 @@
 80235748:wpadGetButtonsHeldRepeat
 8023A994:spsndBGMOn
 8023C494:relInit
-8023C4A4:loadRel
+8023C4A4:relMain
 8023C660:isRelLoaded
 80541AA0:relmgr_wp
 80541AA4:relDecompName

--- a/linker/spm.kr0.lst
+++ b/linker/spm.kr0.lst
@@ -125,7 +125,7 @@
 8022FF34:wpadGetButtonsHeldRepeat
 80234FC0:spsndBGMOn
 80236B00:relInit
-80236B10:loadRel
+80236B10:relMain
 80236CCC:isRelLoaded
 805D79A0:relmgr_wp
 805D79A4:relDecompName

--- a/linker/spm.us0.lst
+++ b/linker/spm.us0.lst
@@ -135,7 +135,7 @@
 802350F4:wpadGetButtonsHeldRepeat
 8023A340:spsndBGMOn
 8023BE40:relInit
-8023BE50:loadRel
+8023BE50:relMain
 8023C00C:isRelLoaded
 8056D1C0:relmgr_wp
 8056D1C4:relDecompName

--- a/linker/spm.us1.lst
+++ b/linker/spm.us1.lst
@@ -135,7 +135,7 @@
 802357B4:wpadGetButtonsHeldRepeat
 8023AA2C:spsndBGMOn
 8023C52C:relInit
-8023C53C:loadRel
+8023C53C:relMain
 8023C6F8:isRelLoaded
 8056CA20:relmgr_wp
 8056CA24:relDecompName

--- a/linker/spm.us2.lst
+++ b/linker/spm.us2.lst
@@ -135,7 +135,7 @@
 80235ACC:wpadGetButtonsHeldRepeat
 8023AD58:spsndBGMOn
 8023C850:relInit
-8023C860:loadRel
+8023C860:relMain
 8023CA1C:isRelLoaded
 8056CBA0:relmgr_wp
 8056CBA4:relDecompName


### PR DESCRIPTION
Breaking:
- None

Other:
- Nand path length constant
- relMain symbol fix
- eu0 lst mem functions