### PR TITLE
Changes from spm-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For use in decomp, the `include` and `decomp` folders should be added to the inc
 
 ## Mods
 
-For use in mods, the `include` and `mod` folder should be added to the include path and an lst from `linker` should be used..
+For use in mods, the `include` and `mod` folder should be added to the include path and an lst from `linker` should be used. If including your compiler's C++ standard library, the preprocessor define `USE_STL` should be used.
 
 # Licensing
 

--- a/include/common.h
+++ b/include/common.h
@@ -36,9 +36,18 @@ typedef signed char s8;
 typedef float f32;
 typedef double f64;
 
-typedef u32 size_t;
-
-#define NULL 0
+#ifdef USE_STL
+    #include <cstddef>
+    static_assert(sizeof(size_t) == 4, "Expected 32-bit size_t");
+#else
+    typedef u32 size_t;
+    #define NULL 0
+    #ifdef __MWERKS__
+        #define offsetof(type, member) ((u32)&((type *)0)->member)
+    #else
+        #define offsetof __builtin_offsetof
+    #endif
+#endif
 
 typedef s32 BOOL;
 
@@ -68,13 +77,6 @@ typedef u8 unk8;
 // Use CW special static assert
 #ifdef __MWERKS__
     #define static_assert(cond, msg) __static_assert(cond, msg) 
-#endif
-
-// Use special offsetof if available
-#ifdef __MWERKS__
-    #define offsetof(type, member) ((u32)&((type *)0)->member)
-#else
-    #define offsetof __builtin_offsetof
 #endif
 
 // Macro for quick size static assert

--- a/include/ios/fs.h
+++ b/include/ios/fs.h
@@ -10,6 +10,7 @@ CPP_WRAPPER(ios::fs)
 
 enum FsErr
 {
+    ERR_FS_EINVAL = -101,
     ERR_FS_ENOENT = -106
 };
 

--- a/include/spm/system.h
+++ b/include/spm/system.h
@@ -83,8 +83,8 @@ const char * getMapdataDvdRoot();
 /*
     Assertion failure handlers
 */
-s32 __assert(const char * filename, s32 line, const char * assertion);
-s32 __assert2(const char * filename, s32 line, const char * assertion, const char * message, ...);
+s32 NORETURN __assert(const char * filename, s32 line, const char * assertion);
+s32 NORETURN __assert2(const char * filename, s32 line, const char * assertion, const char * message, ...);
 
 /*
     Rounds a float to an int

--- a/include/wii/dvd.h
+++ b/include/wii/dvd.h
@@ -1,8 +1,11 @@
 #pragma once
 
 #include <common.h>
+#include <wii/os.h>
 
 CPP_WRAPPER(wii::dvd)
+
+USING(wii::os::OSThreadQueue)
 
 #define DVD_ALIGN 32
 
@@ -32,8 +35,52 @@ SIZE_ASSERT(DVDFileInfo, 0x3c)
 
 typedef void (DVDFICallback)(s32 code, struct _DVDFileInfo * fileInfo);
 
+typedef struct
+{
+    u8 isDir : 8;
+    u32 stringOffset : 24;
+    union
+    {
+        struct
+        {
+            u32 unknown_0x4;
+            u32 next;
+        } dir;
+        struct
+        {
+            u32 startAddr;
+            u32 length;
+        } file;
+    };
+} FstEntry;
+SIZE_ASSERT(FstEntry, 0xc);
+
+typedef struct
+{
+    u32 entrynum;
+    u32 location;
+    u32 next;
+} DVDDir;
+SIZE_ASSERT(DVDDir, 0xc);
+
+typedef struct
+{
+    u32 entrynum;
+    BOOL isDir;
+    const char * name;
+} DVDDirEntry;
+SIZE_ASSERT(DVDDirEntry, 0xc);
+
 // Just a normal string literal, but useful for riivo detection
 extern char devDiStr[]; // "/dev/di"
+
+DECOMP_STATIC(OSThreadQueue __DVDThreadQueue)
+DECOMP_STATIC(u32 MaxEntryNum)
+DECOMP_STATIC(char * FstStringStart)
+DECOMP_STATIC(FstEntry * FstStart)
+DECOMP_STATIC(u32 PauseFlag)
+DECOMP_STATIC(u32 executing);
+
 
 UNKNOWN_FUNCTION(__DVDFSInit);
 s32 DVDConvertPathToEntrynum(const char * path);
@@ -96,7 +143,7 @@ UNKNOWN_FUNCTION(__DVDTestAlarm);
 UNKNOWN_FUNCTION(__DVDStopMotorAsync);
 UNKNOWN_FUNCTION(__DVDRestartMotor);
 UNKNOWN_FUNCTION(__DVDClearWaitingQueue);
-UNKNOWN_FUNCTION(__DVDPushWaitingQueue);
+s32 __DVDPushWaitingQueue(s32 priority, DVDCommandBlock * commandBlock);
 UNKNOWN_FUNCTION(__DVDPopWaitingQueue);
 UNKNOWN_FUNCTION(__DVDCheckWaitingQueue);
 UNKNOWN_FUNCTION(__DVDGetNextWaitingQueue);

--- a/include/wii/fs.h
+++ b/include/wii/fs.h
@@ -1,0 +1,9 @@
+#include <common.h>
+
+CPP_WRAPPER(wii::fs)
+
+s32 ISFS_ReadDir(const char * path, char * names, u32 * nameCount);
+
+// more
+
+CPP_WRAPPER_END()

--- a/include/wii/ipc.h
+++ b/include/wii/ipc.h
@@ -9,9 +9,20 @@ CPP_WRAPPER(wii::ipc)
 */
 enum IosOpenMode
 {
-/* 0x0 */ IOS_OPEN_NONE,
-/* 0x1 */ IOS_OPEN_READ,
-/* 0x2 */ IOS_OPEN_WRITE
+/* 0x0 */ IOS_OPEN_NONE = 0,
+/* 0x1 */ IOS_OPEN_READ = 1,
+/* 0x2 */ IOS_OPEN_WRITE = 2,
+/* 0x3 */ IOS_OPEN_READ_WRITE = IOS_OPEN_READ | IOS_OPEN_WRITE,
+};
+
+/*
+    IOS_Seek mode param
+*/
+enum IosSeekMode
+{
+/* 0x0 */ IOS_SEEK_START,
+/* 0x1 */ IOS_SEEK_CURRENT,
+/* 0x2 */ IOS_SEEK_END,
 };
 
 typedef struct
@@ -20,6 +31,8 @@ typedef struct
 /* 0x4 */ u32 len;
 } Ioctlv;
 SIZE_ASSERT(Ioctlv, 0x8)
+
+DECOMP_STATIC(s32 ipc_lbl_805ae3b4);
 
 UNKNOWN_FUNCTION(IPCInit);
 UNKNOWN_FUNCTION(IPCReadReg);
@@ -31,7 +44,7 @@ UNKNOWN_FUNCTION(strnlen);
 UNKNOWN_FUNCTION(IpcReplyHandler);
 UNKNOWN_FUNCTION(IPCInterruptHandler);
 UNKNOWN_FUNCTION(IPCCltInit);
-UNKNOWN_FUNCTION(__ios_Ipc2);
+s32 __ios_Ipc2(void * param_1, s32 param_2);
 UNKNOWN_FUNCTION(IOS_OpenAsync);
 s32 IOS_Open(const char * path, s32 mode);
 UNKNOWN_FUNCTION(IOS_CloseAsync);
@@ -49,7 +62,7 @@ s32 IOS_Ioctlv(s32 fd, s32 command, s32 inCount, s32 outCount, Ioctlv * vecs);
 UNKNOWN_FUNCTION(IOS_IoctlvReboot);
 UNKNOWN_FUNCTION(iosCreateHeap);
 UNKNOWN_FUNCTION(__iosAlloc);
-UNKNOWN_FUNCTION(iosAllocAligned);
+void * iosAllocAligned(s32 heapId, u32 size, u32 alignment);
 UNKNOWN_FUNCTION(iosFree);
 UNKNOWN_FUNCTION(IPCiProfInit);
 UNKNOWN_FUNCTION(IPCiProfQueueReq);

--- a/include/wii/os/OSThread.h
+++ b/include/wii/os/OSThread.h
@@ -17,6 +17,12 @@ typedef struct _OSThread
 } OSThread;
 SIZE_ASSERT(OSThread, 0x318)
 
+typedef struct
+{
+/* 0x0 */ u8 unknown_0x0[0x8 - 0x0];
+} OSThreadQueue;
+SIZE_ASSERT(OSThreadQueue, 0x8);
+
 FIXED_ADDR(OSThread *, currentThread, 0x800000e4);
 
 typedef void (*ThreadFunc)();
@@ -41,7 +47,7 @@ void OSCancelThread(OSThread * thread);
 UNKNOWN_FUNCTION(OSJoinThread);
 s32 OSResumeThread(OSThread * thread);
 s32 OSSuspendThread(OSThread * thread);
-UNKNOWN_FUNCTION(OSSleepThread);
-UNKNOWN_FUNCTION(OSWakeupThread);
+void OSSleepThread(OSThreadQueue * thread);
+void OSWakeupThread(OSThreadQueue * thread);
 
 CPP_WRAPPER_END()

--- a/linker/spm.eu0.lst
+++ b/linker/spm.eu0.lst
@@ -709,6 +709,9 @@
 // more
 // OSThread.c
 80277ffc:OSSuspendThread
+80278190:OSSleepThread
+8027827c:OSWakeupThread
+// more
 // OSTime
 80278370:OSGetTime
 // more
@@ -725,10 +728,28 @@
 
 // dvd.a
 // dvdfs.c
+    // text
 8027b910:DVDConvertPathToEntrynum
 // more
+    // data
+805aec08:__DVDThreadQueue
+805aec10:MaxEntryNum
+805aec14:FstStringStart
+805aec18:FstStart
+// more
+// dvd.c
+    // text
+8027e840:stateReady
+    // sbss
+805aec24:PauseFlag
+805aeca0:executing
+// more    
 // dvd_broadway.c
 805ae2d8:devDiStr
+// more
+// dvdqueue.c
+    // text
+802803dc:__DVDPushWaitingQueue
 // more
 
 // vi.a
@@ -771,12 +792,21 @@
 80295d90:MEMGetSizeForMBlockExpHeap
 // more
 
+// fs.a
+80296a04:ISFS_ReadDir
+// more
+
 // ipc.a
+    // text
+80297f04:__ios_Ipc2
 80298268:IOS_Open
 80298448:IOS_Close
 802985f0:IOS_Read
 80298b18:IOS_Ioctl
 80298e68:IOS_Ioctlv
+80299360:iosAllocAligned
+    // sdata
+805ae3b4:ipc_lbl_805ae3b4
 // more
 
 // NAND.a


### PR DESCRIPTION
Breaking:
- None

Other:
- Create fs.h
- Expand dvd.h, ipc.h, nand.h, OSThread.h
- Expand dvdmgr.h
- C++ STL compatibility fixes
- NORETURN asserts