### PR TITLE
add evt_ac.h

### DIFF
--- a/include/spm/acdrv.h
+++ b/include/spm/acdrv.h
@@ -109,6 +109,9 @@ void acMain();
 */
 AcEntry * acEntry(s32 type);
 
+/*
+  Returns a value between 12 and 7 depending on how well the player did in the minigame
+*/
 s32 acReturnResults(const char * name);
 
 /*

--- a/include/spm/acdrv.h
+++ b/include/spm/acdrv.h
@@ -47,7 +47,7 @@ typedef struct
 {
 /* 0x0 */ s32 num; // 4
 /* 0x4 */ AcEntry * entries; // array of num length
-} AcWork; 
+} AcWork;
 SIZE_ASSERT(AcWork, 0x8)
 
 DECOMP_STATIC(AcWork acdrv_work)
@@ -109,7 +109,7 @@ void acMain();
 */
 AcEntry * acEntry(s32 type);
 
-UNKNOWN_FUNCTION(func_8003f5d8);
+s32 acReturnResults(const char * name);
 
 /*
     Deletes an entry, calling its deleteFunc and deleting its pausewin entry

--- a/include/spm/dispdrv.h
+++ b/include/spm/dispdrv.h
@@ -46,7 +46,7 @@ void dispReInit();
 /*
     Register a function to be displayed this frame
 */
-void dispEntry(s8 cameraId, s8 renderMode, f32 z, DispCallback * callback, void * callbackParam);
+void dispEntry(f32 z, s8 cameraId, s8 renderMode, DispCallback * callback, void * callbackParam);
 
 void dispSetCurScissor(s32 scissorNo);
 void dispSetScissor(s32 id, u32 field_0, u32 field_4, u32 field_8, u32 field_c);

--- a/include/spm/dispdrv.h
+++ b/include/spm/dispdrv.h
@@ -46,7 +46,7 @@ void dispReInit();
 /*
     Register a function to be displayed this frame
 */
-void dispEntry(f32 z, s8 cameraId, s8 renderMode, DispCallback * callback, void * callbackParam);
+void dispEntry(s8 cameraId, s8 renderMode, f32 z, DispCallback * callback, void * callbackParam);
 
 void dispSetCurScissor(s32 scissorNo);
 void dispSetScissor(s32 id, u32 field_0, u32 field_4, u32 field_8, u32 field_c);

--- a/include/spm/evt_ac.h
+++ b/include/spm/evt_ac.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <common.h>
+
+CPP_WRAPPER(spm::evt_ac)
+
+// evt_ac_entry(const char * name, s32 type)
+EVT_DECLARE_USER_FUNC(evt_ac_entry, 2);
+
+//evt_ac_name_to_ptr(const char * name, EvtVar storage)
+EVT_DECLARE_USER_FUNC(evt_ac_name_to_ptr, 2)
+
+//evt_ac_delete(const char * name)
+EVT_DECLARE_USER_FUNC(evt_ac_delete, 1)
+
+CPP_WRAPPER_END()

--- a/include/spm/evt_ac.h
+++ b/include/spm/evt_ac.h
@@ -1,14 +1,15 @@
 #pragma once
 
 #include <common.h>
+#include <evt_cmd.h>
 
 CPP_WRAPPER(spm::evt_ac)
 
 // evt_ac_entry(const char * name, s32 type)
 EVT_DECLARE_USER_FUNC(evt_ac_entry, 2);
 
-//evt_ac_name_to_ptr(const char * name, EvtVar storage)
-EVT_DECLARE_USER_FUNC(evt_ac_name_to_ptr, 2)
+//evt_ac_return_results(const char * name, s32& ret)
+EVT_DECLARE_USER_FUNC(evt_ac_return_results, 2)
 
 //evt_ac_delete(const char * name)
 EVT_DECLARE_USER_FUNC(evt_ac_delete, 1)

--- a/linker/spm.eu0.lst
+++ b/linker/spm.eu0.lst
@@ -49,6 +49,19 @@
 8003ab80:windowDispGX2_Waku_col
 // more
 
+// acdrv.c
+8003eb4c:acInit
+8003eba0:acReInit
+8003ee44:acMain
+8003f388:acEntry
+8003f5d8:acReturnResults
+8003f5e0:acDelete
+8003f63c:acPauseAll
+8003f67c:acUnpauseAll
+8003f730:acIsRunning
+8003f780:acNameToPtr
+8003f818:acMsgDisp
+
 // animdrv.c
 8004249c:animPoseEntry
 80043410:animPoseSetAnim
@@ -193,7 +206,7 @@
 
 // evt_ac.c
 800df9a8:evt_ac_entry
-800dfa00:evt_ac_name_to_ptr
+800dfa00:evt_ac_return_results
 800dfaac:evt_ac_delete
 
 // evt_door.c

--- a/linker/spm.eu0.lst
+++ b/linker/spm.eu0.lst
@@ -191,6 +191,11 @@
 8050ce30:evt_debug_put_reg_str
 // more
 
+// evt_ac.c
+800df9a8:evt_ac_entry
+800dfa00:evt_ac_name_to_ptr
+800dfaac:evt_ac_delete
+
 // evt_door.c
 // text
 800e11b0:evtDoorGetActiveDoorDesc
@@ -743,7 +748,7 @@
     // sbss
 805aec24:PauseFlag
 805aeca0:executing
-// more    
+// more
 // dvd_broadway.c
 805ae2d8:devDiStr
 // more

--- a/linker/spm.jp0.lst
+++ b/linker/spm.jp0.lst
@@ -460,7 +460,8 @@
 800677D0:fadeSetMapChangeTransition
 8023AB64:spsndCheckBgmPlaying
 
-// new to SPM-RPG-battles1,1,27204:rpg_screen_draw
+// new to SPM-RPG-battles
+1,1,27204:rpg_screen_draw
 1,1,26cc4:rpgHandleMenu
 801B5FC4:npcDelete
 1,1,2cf78:evt_rpg_add_xp
@@ -613,6 +614,11 @@
 8019C0F0:qqsort
 8014E4A4:pouchGetCharInfo
 1,5,de070:lbl_80def2c8
+
+// new to SPM-RPG-Battles V2
+800DFB78:evt_ac_entry
+800DFBD0:evt_ac_name_to_ptr
+800DFC7C:evt_ac_delete
 
 // new to rld3 v1
 8025C158:strcat

--- a/linker/spm.jp0.lst
+++ b/linker/spm.jp0.lst
@@ -617,7 +617,7 @@
 
 // new to SPM-RPG-Battles V2
 800DFB78:evt_ac_entry
-800DFBD0:evt_ac_name_to_ptr
+800DFBD0:evt_ac_return_results
 800DFC7C:evt_ac_delete
 
 // new to rld3 v1

--- a/linker/spm.jp0.lst
+++ b/linker/spm.jp0.lst
@@ -619,6 +619,10 @@
 800DFB78:evt_ac_entry
 800DFBD0:evt_ac_return_results
 800DFC7C:evt_ac_delete
+8003ED2C:acMain
+8003F270:acEntry
+8003F4C0:acReturnResults
+8003F4C8:acDelete
 
 // new to rld3 v1
 8025C158:strcat

--- a/linker/spm.us0.lst
+++ b/linker/spm.us0.lst
@@ -617,7 +617,7 @@
 
 // new to SPM-RPG-Battles V2
 800DFB78:evt_ac_entry
-800DFBD0:evt_ac_name_to_ptr
+800DFBD0:evt_ac_return_results
 800DFC7C:evt_ac_delete
 
 // new to rld3 v1

--- a/linker/spm.us0.lst
+++ b/linker/spm.us0.lst
@@ -619,6 +619,10 @@
 800DFB78:evt_ac_entry
 800DFBD0:evt_ac_return_results
 800DFC7C:evt_ac_delete
+8003ED2C:acMain
+8003F270:acEntry
+8003F4C0:acReturnResults
+8003F4C8:acDelete
 
 // new to rld3 v1
 8025C1B0:strcat

--- a/linker/spm.us0.lst
+++ b/linker/spm.us0.lst
@@ -460,7 +460,8 @@
 800677D0:fadeSetMapChangeTransition
 8023ABBC:spsndCheckBgmPlaying
 
-// new to SPM-RPG-battles1,1,26cc4:rpgHandleMenu
+// new to SPM-RPG-Battles
+1,1,26cc4:rpgHandleMenu
 801B601C:npcDelete
 1,1,2cf78:evt_rpg_add_xp
 800FC9F0:evt_msg_fmt_str
@@ -613,6 +614,11 @@
 8019C100:qqsort
 8014E4A4:pouchGetCharInfo
 1,5,f8f90:lbl_80def2c8
+
+// new to SPM-RPG-Battles V2
+800DFB78:evt_ac_entry
+800DFBD0:evt_ac_name_to_ptr
+800DFC7C:evt_ac_delete
 
 // new to rld3 v1
 8025C1B0:strcat

--- a/linker/spm.us2.lst
+++ b/linker/spm.us2.lst
@@ -619,6 +619,10 @@
 800DFAFC:evt_ac_entry
 800DFB54:evt_ac_return_results
 800DFC00:evt_ac_delete
+8003ECCC:acMain
+8003F210:acEntry
+8003F460:acReturnResults
+8003F468:acDelete
 
 // new to rld3 v1
 8025C950:strcat

--- a/linker/spm.us2.lst
+++ b/linker/spm.us2.lst
@@ -460,7 +460,7 @@
 80067770:fadeSetMapChangeTransition
 8023B5CC:spsndCheckBgmPlaying
 
-// new to SPM-RPG-battles
+// new to SPM-RPG-Battles
 1,1,27204:rpg_screen_draw
 1,1,26cc4:rpgHandleMenu
 801B6390:npcDelete
@@ -614,6 +614,11 @@
 8019C56C:qqsort
 8014E8FC:pouchGetCharInfo
 1,5,f8fb0:lbl_80def2c8
+
+// new to SPM-RPG-Battles V2
+800DFAFC:evt_ac_entry
+800DFB54:evt_ac_name_to_ptr
+800DFC00:evt_ac_delete
 
 // new to rld3 v1
 8025C950:strcat

--- a/linker/spm.us2.lst
+++ b/linker/spm.us2.lst
@@ -617,7 +617,7 @@
 
 // new to SPM-RPG-Battles V2
 800DFAFC:evt_ac_entry
-800DFB54:evt_ac_name_to_ptr
+800DFB54:evt_ac_return_results
 800DFC00:evt_ac_delete
 
 // new to rld3 v1


### PR DESCRIPTION
minor PR but one worth doing imo
added symbols for US2, US0, EU0, and JP0 like I usually do
I think there should be a different name for evt_ac_name_to_ptr since it appears to grab the result of the minigame, whether you did well or bad, not just a pointer. I can give you an example if you'd like, but wanted to bring it up before I made an actual change in ghidra or the headers