### PR TITLE
Changes from practice codes c lib tests

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -25,6 +25,13 @@
     #define HAS_ATTRIBUTE(x) 0
 #endif
 
+// Use required static_assert keyword
+#ifdef __MWERKS__
+    #define static_assert __static_assert 
+#elif !(defined __cplusplus)
+    #define static_assert _Static_assert
+#endif
+
 // Basic types
 
 // Decomp needs long for matching, int is slightly more convenient for casting in mods
@@ -50,7 +57,7 @@ typedef float f32;
 typedef double f64;
 
 #ifdef USE_STL
-    #include <cstddef>
+    #include <stddef.h>
     static_assert(sizeof(size_t) == 4, "Expected 32-bit size_t");
 #else
     typedef u32 size_t;
@@ -64,15 +71,15 @@ typedef double f64;
 
 typedef s32 BOOL;
 
-#ifndef __cplusplus
+#ifdef DECOMP
     #define bool char
 
     #define true 1
     #define false 0
-#endif
 
-#ifndef __cplusplus
     #define wchar_t s16
+#else
+    #include <stdbool.h>
 #endif
 
 #ifdef DECOMP
@@ -86,11 +93,6 @@ typedef u32 Unk;
 typedef u32 Unk32;
 typedef u16 Unk16;
 typedef u8 unk8;
-
-// Use CW special static assert
-#ifdef __MWERKS__
-    #define static_assert(cond, msg) __static_assert(cond, msg) 
-#endif
 
 // Macro for quick size static assert
 #ifndef M2C
@@ -150,7 +152,7 @@ typedef u8 unk8;
     #define ATTRIBUTE(x)
 #endif
 
-#if HAS_ATTRIBUTE(noreturn)
+#if HAS_ATTRIBUTE(noreturn) && (defined __cplusplus) // TODO: the usage sites are probabably what should be fixed here
     #define NORETURN ATTRIBUTE(noreturn)
 #else
     #define NORETURN

--- a/include/spm/memory.h
+++ b/include/spm/memory.h
@@ -24,8 +24,16 @@ USING(wii::gx::GXTexObj)
 USING(wii::mem::MEMHeapHandle)
 
 #define MEM1_HEAP_COUNT 3
+
+// Korean adds a 10th heap
+#ifdef SPM_KR0
+#define MEM2_HEAP_COUNT 7
+#define HEAP_COUNT 10
+#else
 #define MEM2_HEAP_COUNT 6
 #define HEAP_COUNT 9
+#endif
+
 #define SMART_HEAP_ID 7
 #define SMART_ALLOCATION_MAX 2048
 
@@ -39,7 +47,10 @@ enum Heap
 /* 0x5 */ HEAP_WPAD,
 /* 0x6 */ HEAP_SOUND,
 /* 0x7 */ HEAP_SMART,
-/* 0x8 */ HEAP_MEM2_UNUSED
+#ifdef SPM_KR0
+/* 0x8 */ HEAP_FONT,
+#endif
+/* 0x8 / 0x9 */ HEAP_MEM2_UNUSED
 };
 
 enum HeapSizeType
@@ -55,7 +66,7 @@ typedef struct
 } HeapSize;
 SIZE_ASSERT(HeapSize, 0x8)
 
-DECOMP_STATIC(HeapSize memory_size_table[9])
+DECOMP_STATIC(HeapSize memory_size_table[HEAP_COUNT])
 
 typedef struct
 {
@@ -63,7 +74,11 @@ typedef struct
 /* 0x24 */ void * heapStart[HEAP_COUNT]; // pointer to the start of the heap
 /* 0x48 */ void * heapEnd[HEAP_COUNT]; // pointer to the end of the heap
 } MemWork;
+#ifdef SPM_KR0
+SIZE_ASSERT(MemWork, 0x78)
+#else
 SIZE_ASSERT(MemWork, 0x6c)
+#endif
 
 DECOMP_STATIC(MemWork memory_work)
 DECOMP_STATIC(MemWork * memory_wp)

--- a/include/spm/seq_load_sub.h
+++ b/include/spm/seq_load_sub.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <common.h>
+#include <spm/seqdrv.h>
+#include <spm/evtmgr.h>
+#include <spm/filemgr.h>
+
+#include <wii/gx.h>
+
+CPP_WRAPPER(spm::seq_load_sub)
+
+USING(spm::seqdrv::SeqWork)
+USING(spm::evtmgr::EvtEntry)
+USING(spm::filemgr::FileEntry)
+USING(wii::gx::GXColor)
+
+typedef struct {
+    u32 flags;
+    u32 state;
+    FileEntry* fileselTpl;
+    s32 selectedSave;
+    u8 _10[0x2c-0x10];
+    EvtEntry* saveUpdateEvt;
+    s32 saveUpdateEvtId;
+    u8 _34[0x48-0x34];
+    GXColor bgGradientTop;
+    GXColor bgGradientBottom;
+    u8 _50[0x5c-0x50];
+} SeqLoadSubWork;
+SIZE_ASSERT(SeqLoadSubWork, 0x5c)
+
+DECOMP_STATIC(SeqLoadSubWork* seq_load_sub_wp)
+
+s32 loadMain();
+
+CPP_WRAPPER_END()

--- a/include/wii/os/OSMutex.h
+++ b/include/wii/os/OSMutex.h
@@ -1,18 +1,24 @@
 #pragma once
 
 #include <common.h>
+#include <wii/os/OSThread.h>
 
 CPP_WRAPPER(wii::os)
 
-typedef struct
+USING(wii::os::OSThread)
+
+typedef struct _OSMutex
 {
-    u8 unknown_0x0[0x18 - 0x0];
+    u8 unknown_0x0[0x8 - 0x0];
+    OSThread * thread;
+    s32 count;
+    u8 unknown_0x10[0x10 - 0x8];
 } OSMutex;
 SIZE_ASSERT(OSMutex, 0x18)
 
 void OSInitMutex(OSMutex * mutex);
-UNKNOWN_FUNCTION(OSLockMutex);
-UNKNOWN_FUNCTION(OSUnlockMutex);
+void OSLockMutex(OSMutex * mutex);
+void OSUnlockMutex(OSMutex * mutex);
 UNKNOWN_FUNCTION(__OSUnlockAllMutex);
 
 CPP_WRAPPER_END()

--- a/include/wii/os/OSThread.h
+++ b/include/wii/os/OSThread.h
@@ -7,25 +7,57 @@ CPP_WRAPPER(wii::os)
 
 USING(wii::os::OSContext)
 
-typedef struct _OSThread
-{
-    OSContext context;
-    u8 unknown_0x2c8[0x2fc - 0x2c8];
-    struct _OSThread * next;
-    struct _OSThread * prev;
-    u8 unknown_0x304[0x318 - 0x304];
-} OSThread;
-SIZE_ASSERT(OSThread, 0x318)
+struct _OSMutex;
+struct _OSThread;
 
 typedef struct
 {
-/* 0x0 */ u8 unknown_0x0[0x8 - 0x0];
+/* 0x0 */ struct _OSThread * next;
+/* 0x4 */ struct _OSThread * prev;
+} OSThreadLink;
+SIZE_ASSERT(OSThreadLink, 0x8)
+
+typedef struct
+{
+/* 0x0 */ struct _OSThread * head;
+/* 0x4 */ struct _OSThread * tail;
 } OSThreadQueue;
 SIZE_ASSERT(OSThreadQueue, 0x8)
 
-FIXED_ADDR(OSThread *, currentThread, 0x800000e4);
+typedef struct _OSThread
+{
+/* 0x000 */ OSContext context;
+/* 0x2C8 */ u16 state;
+/* 0x2CA */ u16 attr;
+/* 0x2CC */ s32 suspend;
+/* 0x2D0 */ s32 priority;
+/* 0x2D4 */ s32 base;
+/* 0x2D8 */ void * val;
+/* 0x2DC */ OSThreadQueue * queue;
+/* 0x2E0 */ OSThreadLink link;
+/* 0x2E8 */ OSThreadQueue queueJoin;
+/* 0x2F0 */ struct _OSMutex * mutex;
+/* 0x2F4 */ u8 unknown_0x2f4[0x2fc - 0x2f4];
+/* 0x2FC */ OSThreadLink linkActive;
+/* 0x304 */ u8 * stackBase;
+/* 0x308 */ u32 * stackEnd;
+/* 0x30C */ s32 error;
+/* 0x310 */ void * specific[2];
+} OSThread;
+SIZE_ASSERT(OSThread, 0x318)
 
-typedef void (*ThreadFunc)();
+FIXED_ADDR(OSThread *, OS_CURRENT_THREAD, 0x800000e4);
+FIXED_ADDR(OSThreadQueue, OS_THREAD_QUEUE, 0x800000dc);
+
+typedef void * (ThreadFunc)(void *);
+
+#define OS_THREAD_DETACHED 1
+
+#define OS_THREAD_STATE_EXITED 0
+#define OS_THREAD_STATE_READY 1
+#define OS_THREAD_STATE_RUNNING 2
+#define OS_THREAD_STATE_SLEEPING 4
+#define OS_THREAD_STATE_MORIBUND 8
 
 UNKNOWN_FUNCTION(DefaultSwitchThreadCallback);
 UNKNOWN_FUNCTION(__OSThreadInit);
@@ -40,11 +72,11 @@ UNKNOWN_FUNCTION(__OSPromoteThread);
 UNKNOWN_FUNCTION(SelectThread);
 UNKNOWN_FUNCTION(__OSReschedule);
 void OSYieldThread();
-s32 OSCreateThread(OSThread * thread, ThreadFunc * func, void * funcParam, void * stackTop,
-                   u32 stackSize, s32 priority, u16 param_7);
-UNKNOWN_FUNCTION(OSExitThread);
+BOOL OSCreateThread(OSThread * thread, ThreadFunc * func, void * funcParam, void * stackTop,
+                   u32 stackSize, s32 priority, u16 attr);
+void OSExitThread(void * val);
 void OSCancelThread(OSThread * thread);
-UNKNOWN_FUNCTION(OSJoinThread);
+BOOL OSJoinThread(OSThread * thread, void ** outVal);
 s32 OSResumeThread(OSThread * thread);
 s32 OSSuspendThread(OSThread * thread);
 void OSSleepThread(OSThreadQueue * thread);

--- a/linker/spm.eu0.lst
+++ b/linker/spm.eu0.lst
@@ -1,6 +1,7 @@
 /* OS Globals */
 
-800000e4:currentThread
+800000dc:OS_THREAD_QUEUE
+800000e4:OS_CURRENT_THREAD
 800030c8:firstRel
 800030cc:lastRel
 // more
@@ -477,6 +478,13 @@
 // data
 80512360:seqWork
 
+//seq_load_sub.c
+// text
+8017d1ac:loadMain
+// data
+805ae0d0:seq_load_sub_wp
+
+
 // pausewin.c
 // text
 80184c18:pausewinEntry
@@ -577,7 +585,7 @@
 801a62f0:__memFree
 801a6e34:__dl__FPv
 // data
-8042a408:size_table
+8042a408:memory_size_table
 // sdata
 805ae168:memory_wp
 805ae16c:memory_swp
@@ -675,6 +683,8 @@
 8023edcc:nandUpdateSave
 8023efe0:nandLoadSave
 // more
+// data
+805ae1b0:nandmgr_wp
 
 // homebuttondrv.c
 // text
@@ -691,7 +701,6 @@
 // runtime.c
 802560a4:__div2i
 // more
-
 // MSL_C.PPCEABI.bare.H.a
 // printf.c
 8025cf40:vsprintf
@@ -702,7 +711,6 @@
 // string.c
 8025ec04:strstr
 // more
-
 // string.c
 8025a874:memmove
 8025a998:memcmp
@@ -714,10 +722,8 @@
 8025ebd4:strchr
 80267018:strlen
 // more
-
 // s_cos.c
 80263ea0:cos
-
 // s_sin.c
 802642ac:sin
 
@@ -766,16 +772,23 @@
 80276198:OSRestart
 // more
 // OSThread.c
+80277154:OSGetCurrentThread
 802776c0:OSYieldThread
 802776fc:OSCreateThread
+80277968:OSExitThread
+80277a4c:OSCancelThread
 80277d64:OSResumeThread
 80277ffc:OSSuspendThread
 80278190:OSSleepThread
 8027827c:OSWakeupThread
 // more
-// OSTime
+// OSTime.c
 80278370:OSGetTime
 // more
+// OSMutex.c
+80275a50:OSInitMutex
+80275a88:OSLockMutex
+80275b64:OSUnlockMutex
 
 // mtx.a
 // mtx.c

--- a/linker/spm.jp0.lst
+++ b/linker/spm.jp0.lst
@@ -1,5 +1,5 @@
 // OS Globals
-800000e4:currentThread
+800000e4:OS_CURRENT_THREAD
 800030c8:firstRel
 800030cc:lastRel
 
@@ -128,7 +128,7 @@
 803BE018:seq_data
 801A5624:__memAlloc
 801A56A8:__memFree
-803BFC68:size_table
+803BFC68:memory_size_table
 80542488:memory_wp
 8054248C:memory_swp
 80235060:wpadGetButtonsHeld
@@ -678,3 +678,9 @@
 80274E14:OSYieldThread
 80275378:OSResumeThread
 802580F0:memcmp
+
+// new to v10
+805423F0:seq_load_sub_wp
+805424D0:nandmgr_wp
+80238A9C:spsndSFXOn
+8017C4F0:loadMain

--- a/linker/spm.jp1.lst
+++ b/linker/spm.jp1.lst
@@ -1,5 +1,5 @@
 // OS Globals
-800000e4:currentThread
+800000e4:OS_CURRENT_THREAD
 800030c8:firstRel
 800030cc:lastRel
 
@@ -127,7 +127,7 @@
 803BF198:seq_data
 801A566C:__memAlloc
 801A56F0:__memFree
-803C0DE8:size_table
+803C0DE8:memory_size_table
 80541A68:memory_wp
 80541A6C:memory_swp
 8023570C:wpadGetButtonsHeld
@@ -469,3 +469,9 @@
 8026F1F8:Run
 80542470:SaveStart
 80542474:SaveEnd
+
+// new to v10
+805419D0:seq_load_sub_wp
+80541AB0:nandmgr_wp
+80239148:spsndSFXOn
+8017C538:loadMain

--- a/linker/spm.kr0.lst
+++ b/linker/spm.kr0.lst
@@ -1,5 +1,5 @@
 // OS Globals
-800000e4:currentThread
+800000e4:OS_CURRENT_THREAD
 800030c8:firstRel
 800030cc:lastRel
 
@@ -117,7 +117,7 @@
 804597B8:seq_data
 8019EB44:__memAlloc
 8019EBC8:__memFree
-8045B3C8:size_table
+8045B3C8:memory_size_table
 805D7968:memory_wp
 805D796C:memory_swp
 8022FEF8:wpadGetButtonsHeld
@@ -459,3 +459,9 @@
 80273B28:Run
 805d8308:SaveStart
 805d830c:SaveEnd
+
+// new to v10
+805D78D0:seq_load_sub_wp
+805d79b0:nandmgr_wp
+80233884:spsndSFXOn
+80178EFC:loadMain

--- a/linker/spm.us0.lst
+++ b/linker/spm.us0.lst
@@ -1,5 +1,5 @@
 // OS Globals
-800000e4:currentThread
+800000e4:OS_CURRENT_THREAD
 800030c8:firstRel
 800030cc:lastRel
 
@@ -127,7 +127,7 @@
 803E8DC8:seq_data
 801A5634:__memAlloc
 801A56B8:__memFree
-803EAA08:size_table
+803EAA08:memory_size_table
 8056D188:memory_wp
 8056D18C:memory_swp
 802350B8:wpadGetButtonsHeld
@@ -677,3 +677,9 @@
 80274E64:OSYieldThread
 802753C8:OSResumeThread
 80258148:memcmp
+
+// new to v10
+8017c500:loadMain
+8056d0f0:seq_load_sub_wp
+8056d1d0:nandmgr_wp
+80238af4:spsndSFXOn

--- a/linker/spm.us1.lst
+++ b/linker/spm.us1.lst
@@ -1,5 +1,5 @@
 // OS Globals
-800000e4:currentThread
+800000e4:OS_CURRENT_THREAD
 800030c8:firstRel
 800030cc:lastRel
 
@@ -127,7 +127,7 @@
 803EA128:seq_data
 801A5690:__memAlloc
 801A5714:__memFree
-803EBD68:size_table
+803EBD68:memory_size_table
 8056C9E8:memory_wp
 8056C9EC:memory_swp
 80235778:wpadGetButtonsHeld
@@ -469,3 +469,9 @@
 8026F298:Run
 8056d3f0:SaveStart
 8056d3f4:SaveEnd
+
+// new to v10
+8056C950:seq_load_sub_wp
+8056CA30:nandmgr_wp
+802391E0:spsndSFXOn
+8017C55C:loadMain

--- a/linker/spm.us2.lst
+++ b/linker/spm.us2.lst
@@ -1,5 +1,5 @@
 // OS Globals
-800000e4:currentThread
+800000e4:OS_CURRENT_THREAD
 800030c8:firstRel
 800030cc:lastRel
 
@@ -127,7 +127,7 @@
 803EA308:seq_data
 801A59A8:__memAlloc
 801A5A2C:__memFree
-803EBF48:size_table
+803EBF48:memory_size_table
 8056CB68:memory_wp
 8056CB6C:memory_swp
 80235A90:wpadGetButtonsHeld
@@ -677,3 +677,9 @@
 80275610:OSYieldThread
 80275CB4:OSResumeThread
 802588e8:memcmp
+
+// new to v10
+8056CAD0:seq_load_sub_wp
+8056CBB0:nandmgr_wp
+8023950C:spsndSFXOn
+8017C96C:loadMain


### PR DESCRIPTION
Breaking:
- You may no longer use `-nostdinc` in mods, the compilers headers are preferred over redefining types (`-nostdlib` is still usable to prevent linking the actual libraries)
- `currentThread` renamed to OS_CURRENT_THREAD
- Some OSThread fields corrected

**Other**
- common.h fixes for C in mod environments
- Correct memory.h for kr0
- Create seq_load_sub.h
- Expand OSMutex.h
- Expand OSThread.h